### PR TITLE
V24.10.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Besu - Hyperledger Ethereum client.
     sudo snap get besu
 
     # Set defaults service-args
-    sudo snap set besu service-args="--network=mainnet --data-path=$SNAP_COMMON/data"
+    sudo snap set besu service-args="--network=mainnet --data-path=$SNAP_COMMON/data --plugin-continue-on-error=true"
 
 ### Set snap not to restart besu after upgrade.
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -26,7 +26,7 @@ parts:
     build-packages: 
       - openjdk-21-jdk-headless
     source: https://github.com/hyperledger/besu.git
-    source-tag: 24.9.1
+    source-tag: 24.10.0
     source-depth: 1
     stage-packages:
       - openjdk-21-jre-headless


### PR DESCRIPTION
https://github.com/hyperledger/besu/pull/7662 a new flag has been introduced to enable the client to still run on plugin errors `--plugin-continue-on-error=<true/false>` , it will log it and continue running if it set to true and will halt if it is set to false